### PR TITLE
also matches "*://calendar.proton.me/*"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
 
   "content_scripts": [
     {
-      "matches": ["*://calendar.protonmail.com/*"],
+      "matches": ["*://calendar.protonmail.com/*", "*://calendar.proton.me/*"],
       "js": ["./improvements.js"]
     }
   ]


### PR DESCRIPTION
Proton has changed the URL for Proton Calendar. This PR adds the new domain to the manifest.