### PR TITLE
Remove Escape hotkey

### DIFF
--- a/improvements.js
+++ b/improvements.js
@@ -23,11 +23,6 @@ document.onkeydown = function(evt) {
     }
   }
 
-  // Close popovers
-  if (evt.keyCode === 27) { // escape
-    document.querySelector('button[title="Close popover"]').click();
-  }
-
   let activeElement = document.activeElement;
   const inputs = ['input', 'textarea'];
 


### PR DESCRIPTION
Proton calendar supports this by default, and this line just throws errors.